### PR TITLE
fix: 修复Docker sh脚本未将SIGTERM信号转发给OPQBot进程的问题

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,4 +14,4 @@ if [[ "$port" != "" ]] ; then
     echo "已经将机器人地址设置为$port"
 fi
 echo "开始执行OPQBot"
-/apps/OPQBot
+exec /apps/OPQBot


### PR DESCRIPTION
该问题将导致Docker在停止容器时由于OPQBot程序无法接受到SIGTERM信号，超时被SIGKILL信号结束。